### PR TITLE
Issue #2986567 API request failure causes valid domains to be invalidated

### DIFF
--- a/skimlinks.module
+++ b/skimlinks.module
@@ -56,7 +56,12 @@ function skimlinks_cron() {
       skimlinks_validate_merchant($item->domain);
     }
     catch (Exception $e) {
-      watchdog_exception('skimlinks', $e);
+      watchdog('skimlinks', $e->getMessage());
+      // Stop processing if we have hit the API limit.
+      // Continue processing if the request failed for any other reason.
+      if ($e->getCode() === 406) {
+        break;
+      }
     }
   }
 }
@@ -464,7 +469,7 @@ function _skimlinks_entity_update_known_domains($entity) {
                 skimlinks_validate_merchant($domain, 5);
               }
               catch (Exception $e) {
-                watchdog_exception('skimlinks', $e);
+                watchdog('skimlinks', $e->getMessage());
               }
             }
           }
@@ -517,11 +522,25 @@ function skimlinks_merchant_api_call($domain, $timeout = 10) {
   curl_setopt($ch, CURLOPT_URL, "$api_endpoint?$query");
 
   $result = curl_exec($ch);
-  $error = curl_error($ch) . ' - Domain: ' . $domain;
-  curl_close($ch);
+  $response_code = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
 
   if($result === FALSE) {
-    throw new Exception($error);
+    $error_message = t('!curl_error - Domain: !domain', array(
+      '!curl_error' => curl_error($ch),
+      '!domain' => $domain,
+    ));
+  }
+  elseif ($response_code !== 200) {
+    $error_message = t('!code status code returned checking domain: !domain', array(
+      '!code' => $response_code,
+      '!domain' => $domain,
+    ));
+  }
+
+  curl_close($ch);
+
+  if (!empty($error_message)) {
+    throw new Exception($error_message, $response_code);
   }
 
   return json_decode($result);

--- a/skimlinks.module
+++ b/skimlinks.module
@@ -56,7 +56,7 @@ function skimlinks_cron() {
       skimlinks_validate_merchant($item->domain);
     }
     catch (Exception $e) {
-      watchdog_exception('skimlinks', $e->getMessage());
+      watchdog_exception('skimlinks', $e);
     }
   }
 }
@@ -464,7 +464,7 @@ function _skimlinks_entity_update_known_domains($entity) {
                 skimlinks_validate_merchant($domain, 5);
               }
               catch (Exception $e) {
-                watchdog_exception('skimlinks', $e->getMessage());
+                watchdog_exception('skimlinks', $e);
               }
             }
           }
@@ -499,6 +499,7 @@ function skimlinks_validate_merchant($domain, $timeout = 10) {
  */
 function skimlinks_merchant_api_call($domain, $timeout = 10) {
   $api_endpoint = check_plain(variable_get('skimlinks_merchant_api_endpoint'));
+
   $parameters = array(
     'apikey' => check_plain(variable_get('skimlinks_merchant_api_key')),
     'account_id' => check_plain(variable_get('skimlinks_merchant_api_account_id')),
@@ -516,10 +517,11 @@ function skimlinks_merchant_api_call($domain, $timeout = 10) {
   curl_setopt($ch, CURLOPT_URL, "$api_endpoint?$query");
 
   $result = curl_exec($ch);
+  $error = curl_error($ch) . ' - Domain: ' . $domain;
   curl_close($ch);
 
   if($result === FALSE) {
-    throw new Exception(curl_error($ch) . ' - Domain: ' . $domain);
+    throw new Exception($error);
   }
 
   return json_decode($result);

--- a/skimlinks.module
+++ b/skimlinks.module
@@ -56,7 +56,7 @@ function skimlinks_cron() {
       skimlinks_validate_merchant($item->domain);
     }
     catch (Exception $e) {
-      watchdog_exception('cron', $e->getMessage());
+      watchdog_exception('skimlinks', $e->getMessage());
     }
   }
 }
@@ -460,7 +460,12 @@ function _skimlinks_entity_update_known_domains($entity) {
             $domain = _skimlinks_get_host($href);
             // If the domain isn't yet known, look it up straight away.
             if (!empty($domain) && !_skimlinks_domain_exists($domain)) {
-              skimlinks_validate_merchant($domain, 2);
+              try {
+                skimlinks_validate_merchant($domain, 5);
+              }
+              catch (Exception $e) {
+                watchdog_exception('skimlinks', $e->getMessage());
+              }
             }
           }
         }
@@ -507,12 +512,17 @@ function skimlinks_merchant_api_call($domain, $timeout = 10) {
   curl_setopt($ch, CURLOPT_FRESH_CONNECT, TRUE);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
   curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+  curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
   curl_setopt($ch, CURLOPT_URL, "$api_endpoint?$query");
 
-  $result = json_decode(curl_exec($ch));
+  $result = curl_exec($ch);
   curl_close($ch);
 
-  return $result;
+  if($result === FALSE) {
+    throw new Exception(curl_error($ch) . ' - Domain: ' . $domain);
+  }
+
+  return json_decode($result);
 }
 
 /**

--- a/skimlinks.module
+++ b/skimlinks.module
@@ -650,12 +650,26 @@ function skimlinks_known_domains_update($domain, $valid = NULL) {
     ))
     ->execute();
 
-  // Clear cache so that it will be checked again.
-  $cid = _skimlinks_domain_exists_cid($domain);
-  cache_clear_all($cid, 'cache', TRUE);
-  drupal_static_reset($cid);
+  _skimlinks_clear_domain_cache($domain);
 
   return TRUE;
+}
+
+/**
+ * Clear the cache for the provided domain.
+ *
+ * @param $domain
+ */
+function _skimlinks_clear_domain_cache($domain) {
+  // Clear cache so that it will be checked again.
+  $cids = array(
+    _skimlinks_domain_exists_cid($domain),
+    _skimlinks_domain_allowed_cid($domain),
+  );
+  foreach ($cids as $cid) {
+    cache_clear_all($cid, 'cache', TRUE);
+    drupal_static_reset($cid);
+  }
 }
 
 /**

--- a/skimlinks.module
+++ b/skimlinks.module
@@ -51,7 +51,7 @@ function skimlinks_cron() {
 
   $end = time() + (int) variable_get('skimlinks_cron_process_time', 60);
   $expired_domains = skimlinks_get_expired_domains_query();
-  while (time() < $end && ($item = $expired_domains->fetchObject())) {
+  while (time() < $end && _skimlinks_within_api_rate_limit() && ($item = $expired_domains->fetchObject())) {
     try {
       skimlinks_validate_merchant($item->domain);
     }
@@ -64,6 +64,30 @@ function skimlinks_cron() {
       }
     }
   }
+}
+
+/**
+ * Check that rate limit hasn't been reached.
+ *
+ * @return bool
+ */
+function _skimlinks_within_api_rate_limit() {
+  $time_start = &drupal_static(__FUNCTION__ . '_time_start', time());
+  $lookups = &drupal_static(__FUNCTION__ . '_lookups', 0);
+
+  # Reset lookups each minute.
+  if ((time() - $time_start) >= 60) {
+    $time_start = time();
+    $lookups = 0;
+  }
+
+  # Return FALSE if we have hit the API limit, which is
+  # 40 requests per min per API key.
+  if ($lookups++ >= 40) {
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 /**


### PR DESCRIPTION
See: https://www.drupal.org/project/skimlinks/issues/2986567

- Clears allowed domain cache when domains are updated
- Skips domain update when CURL error occurs
- Skips domain update when API response code is not 200
- Stops cron before hitting rate limit of 40 requests per minute (within same process)
- Stops cron process when 406 response code is returned (hit API rate limit) - see http://developers.skimlinks.com/merchant.html – this could occur if cron is run in more than one process and/or run more than once per minute.

## Testing API failure
You can test the exception by forcing the call to fail in `skimlinks_merchant_api_call()`

```
if ($domain == '{host_to_check}') {
  $api_endpoint = 'http://{local_site_domain}/';
  $timeout = 1;
}
```

## Testing API rate limit
Increase process time so that more that 40 requests are made per minute:
`drush vset skimlinks_cron_process_time 60`

Run
`drush ev "skimlinks_cron();"`